### PR TITLE
Login form not showing up

### DIFF
--- a/src/es6/Components/LoginPanel.jsx
+++ b/src/es6/Components/LoginPanel.jsx
@@ -72,7 +72,7 @@ export default class LoginPanel extends Component {
   }
 
   findSession(sessionName) {
-    if (sessionName === undefined) {
+    if (sessionName === undefined || sessionName === null) {
       return false;
     }
     return window.lightdm.sessions.filter((session) => session.name.toLowerCase() === sessionName.toLowerCase() || session.key.toLowerCase() === sessionName.toLowerCase())[0];


### PR DESCRIPTION
I was getting this error in the greeter log file:

file:///usr/share/lightdm-webkit/themes/lightdm-webkit-theme-aether/src/js/Aether.js:2:18613: CONSOLE ERROR TypeError: null is not an object (evaluating 'e.toLowerCase')

And no login form was ever appearing on my screen. Setting the relevant part like this directly in the Aether.js file solved the problem:

                key: "findSession",
                value: function(e) {
                    return null !== e && void 0 !== e && window.lightdm.sessions.filter(function(t) {
                        return t.name.toLowerCase() === e.toLowerCase() || t.key.toLowerCase() === e.toLowerCase()
                    })[0]
                }

Is there any reasonable cause for my error in the first place? Would the change to this source file be the correct way to fix it?