### PR TITLE
Use config file support

### DIFF
--- a/src/js/Components/Settings/sections/General.jsx
+++ b/src/js/Components/Settings/sections/General.jsx
@@ -147,6 +147,14 @@ export const GeneralSection = (props) => {
             value={ settings.hostname_enabled }
             boundFunction={ props.settingsToggleBinary.bind(this, 'hostname_enabled') }
           />
+
+          <h4>Configuration</h4>
+          <hr />
+          <Checkbox
+            name={ "Use .conf settings" }
+            value={ settings.use_lightdm_conf }
+            boundFunction={ props.settingsToggleBinary.bind(this, 'use_lightdm_conf') }
+          />
         </ul>
       </div>
     </div>

--- a/src/js/Components/Settings/sections/General.jsx
+++ b/src/js/Components/Settings/sections/General.jsx
@@ -20,6 +20,11 @@ const onLogoChange = (props, e) => {
   });
 };
 
+const toggleConfig = (props) => {
+  props.dispatch({
+    "type": 'SETTINGS_TOGGLE_CONFIG'
+  });
+};
 
 const LogoChooser = (props) => {
   let logos = FileOperations.getLogos();
@@ -153,7 +158,7 @@ export const GeneralSection = (props) => {
           <Checkbox
             name={ "Use .conf settings" }
             value={ settings.use_lightdm_conf }
-            boundFunction={ props.settingsToggleBinary.bind(this, 'use_lightdm_conf') }
+            boundFunction={ toggleConfig.bind(this, props) }
           />
         </ul>
       </div>

--- a/src/js/Logic/Settings.js
+++ b/src/js/Logic/Settings.js
@@ -17,8 +17,17 @@ export function requestSetting(setting, defaultSetting=undefined) {
     return false;
   }
 
-  // Continue as usual
-  let result = localStorage.getItem(setting);
+  let result = null;
+  if (localStorage.getItem('use_lightdm_conf') === 'true') {
+    try {
+      result = window.config.get_str('aether', setting);
+    } catch (e) {
+      result = localStorage.getItem(setting);
+    }
+  }
+  else {
+    result = localStorage.getItem(setting);
+  }
 
   if (result === null || result === undefined) {
     return defaultSetting;

--- a/src/js/Reducers/SettingsReducer.js
+++ b/src/js/Reducers/SettingsReducer.js
@@ -1,4 +1,5 @@
 /* eslint { no-redeclare: 0 } */
+import * as FileOperations from 'Logic/FileOperations';
 import * as Settings from '../Logic/Settings';
 import { setPageZoom } from '../Utils/Utils';
 
@@ -162,6 +163,32 @@ export const SettingsReducer = (state, action) => {
       }
 
       return state;
+
+    case 'SETTINGS_TOGGLE_CONFIG':
+      localStorage.setItem('use_lightdm_conf', !state.settings.use_lightdm_conf);
+
+      var dir              = FileOperations.getWallpaperDirectory();
+      var wallpaper        = Settings.requestSetting('wallpaper', 'space-1.jpg');
+      var cyclerForeground = document.querySelectorAll('.wallpaper-foreground')[0];
+
+      var newSettings = {
+        ...state.settings,
+        "use_lightdm_conf": !state.settings.use_lightdm_conf
+      };
+
+      for (let key in state.settings) {
+        newSettings[key] = Settings.requestSetting(key, state.settings[key]);
+      }
+
+      setTimeout(() => {
+        cyclerForeground.style.background = `url('${ dir }${ wallpaper }')`;
+        cyclerForeground.style.backgroundPosition = "center";
+        cyclerForeground.style.backgroundSize = "cover";
+      }, 600);
+
+      var newState = { ...state, "settings": newSettings };
+
+      return newState;
 
     default:
       return state;

--- a/src/js/Reducers/SettingsReducer.js
+++ b/src/js/Reducers/SettingsReducer.js
@@ -31,6 +31,8 @@ export function addAdditionalSettings(state) {
 
     "hostname_enabled": true,
 
+    "use_lightdm_conf": false,
+
     "user_switcher_enabled": true,
 
     "command_shutdown_enabled": true,


### PR DESCRIPTION
Features

- Adds an option to use a config file instead of manually setting on the login screen
- Preview config file on change of checkbox
- Use the default/localStorage value if a setting is not specified in config file

Why?
QOL for users who seldom change themes using the cli. Just like GTK apps, the theme will change instantly when the config file is updated. The config will be `/etc/lightdm/lightdm-webkit2-greeter.conf`.
Sample config file:

```

[greeter]
debug_mode          = false
detect_theme_errors = true
screensaver_timeout = 300
secure_mode         = true
time_format         = LT
time_language       = auto
webkit_theme        = lightdm-webkit-theme-aether

[branding]
background_images = /usr/share/pixmaps/backgrounds/
logo              = /usr/share/pixmaps/archlinux-logo.svg
user_image        = /usr/share/pixmaps/archlinux-user.svg

[aether]
wallpaper                             = nier-2b-circle.jpg
distro                                = /usr/share/lightdm-webkit/themes/lightdm-webkit-theme-aether/src/img/logos/archlinux.png
default_user                          = kev
page_zoom                             = 1.0
avatar_enabled                        = true
avatar_size                           = 200px
avatar_shape                          = circle
font_scale                            = 1.0
date_enabled                          = true
date_format                           = <em>%A</em>, the <em>%o</em> of <em>%B</em>
experimental_stars_enabled            = false
time_enabled                          = true
time_format                           = %H:%M
hostname_enabled                      = true
user_switcher_enabled                 = true
command_shutdown_enabled              = true
command_reboot_enabled                = true
command_hibernate_enabled             = true
command_sleep_enabled                 = true
style_command_logo_desaturate         = false
style_command_logo_brightness         = 100
style_command_icons_enabled           = true
style_command_text_align              = left
style_command_background_color        = #050d10dd
style_command_icon_color              = #e44742
style_command_text_color              = #e44742
style_login_border_color              = #ffffff
style_login_border_enabled            = false
style_login_button_color              = #ffffff
style_login_button_text_color         = #e44742
style_login_gradient_top_color        = #050d10dd
style_login_gradient_bottom_color     = #050d10dd
style_login_username_bold             = true
style_login_username_capitalization   = default
style_login_username_color            = #ffffff
style_login_username_italic           = true
window_border_radius                  = 4px
window_font_size                      = 1em
```