### PR TITLE
Fix folder name manual installation copies to

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ NOTE: Users performing a manual installation directly from Github should replace
 ```
 # If you prefer the last stable release, download from the releases page instead: https://github.com/NoiSek/Aether/releases/latest
 git clone git@github.com:NoiSek/Aether.git
-sudo cp --recursive Aether /usr/share/lightdm-webkit/themes/Aether
+sudo cp --recursive Aether /usr/share/lightdm-webkit/themes/lightdm-webkit-theme-aether
 
 # Set default lightdm-webkit2-greeter theme to Aether
 sudo sed -i 's/^webkit_theme\s*=\s*\(.*\)/webkit_theme = lightdm-webkit-theme-aether #\1/g' /etc/lightdm/lightdm-webkit2-greeter.conf


### PR DESCRIPTION
As there are some cases in which folder name is hardcoded, and even changing it within /etc/lightdm/lightdm-webkit2-greeter.conf leaves some errors.

I think it might solve #18, but it might be other issue I'm not aware of.

It definitely solved my problem, with some parts of the UI missing and constant errors "theme might have not loaded properly".