### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,12 +65,12 @@ pacaur -S lightdm-webkit-theme-aether
 
 This assumes that you already have lightdm and lightdm-webkit2-greeter installed (but not configured).
 
-NOTE: Users performing a manual installation directly from Github should replace the `lightdm-webkit-theme-aether` values in the provided sed commands with `Aether` to match the name of the theme directory. Users performing a manual installation from the AUR should make no changes.
+NOTE: Users performing a manual installation must put the theme under `/usr/share/lightdm-webkit/themes/lightdm-webkit-theme-aether`. Otherwise the theme will have errors, as the theme looks for files under that directory. If you are performing a manual installation from the AUR, this should happen naturally.
 
 ```
 # If you prefer the last stable release, download from the releases page instead: https://github.com/NoiSek/Aether/releases/latest
 git clone git@github.com:NoiSek/Aether.git
-sudo cp --recursive Aether /usr/share/lightdm-webkit/themes/Aether
+sudo cp --recursive Aether /usr/share/lightdm-webkit/themes/lightdm-webkit-theme-aether
 
 # Set default lightdm-webkit2-greeter theme to Aether
 sudo sed -i 's/^webkit_theme\s*=\s*\(.*\)/webkit_theme = lightdm-webkit-theme-aether #\1/g' /etc/lightdm/lightdm-webkit2-greeter.conf


### PR DESCRIPTION
Instruct users to use `lightdm-webkit-theme-aether` as their directory instead of `Aether` during manual installation.

This is a soft-fix for #85 